### PR TITLE
Gavin patches

### DIFF
--- a/mrdetect.wdl
+++ b/mrdetect.wdl
@@ -201,7 +201,7 @@ task detectSNVs {
 	command <<<
 		set -euo pipefail
 
-		plasmaSampleName=$(basename $plasmabam)
+		plasmaSampleName=$(basename ~{plasmabam})
 
 		~{pullreadsScript} \
 			--bam ~{plasmabam} \

--- a/mrdetect.wdl
+++ b/mrdetect.wdl
@@ -214,7 +214,7 @@ task detectSNVs {
 			--output_file PLASMA_VS_TUMOR.svm.tsv
 
 		~{filterAndDetectScript} \
-			--vcfid ~{tumorSampleName} --bamid ~{plasmaSampleName} \
+			--vcfid ~{tumorSampleName} --bamid $plasmaSampleName \
 			--svm PLASMA_VS_TUMOR.svm.tsv \
 			--vcf ~{tumorvcf} \
 			--output ./ \

--- a/mrdetect.wdl
+++ b/mrdetect.wdl
@@ -201,7 +201,7 @@ task detectSNVs {
 	command <<<
 		set -euo pipefail
 
-		plasmaSampleName = basename(plasmabam)
+		plasmaSampleName=$(basename plasmabam)
 
 		~{pullreadsScript} \
 			--bam ~{plasmabam} \

--- a/mrdetect.wdl
+++ b/mrdetect.wdl
@@ -201,7 +201,7 @@ task detectSNVs {
 	command <<<
 		set -euo pipefail
 
-		plasmaSampleName=$(basename plasmabam)
+		plasmaSampleName=$(basename $plasmabam)
 
 		~{pullreadsScript} \
 			--bam ~{plasmabam} \

--- a/mrdetect.wdl
+++ b/mrdetect.wdl
@@ -4,7 +4,7 @@ workflow mrdetect {
 	input {
 		File? plasmabam
 		File? plasmabai
-		String? outputFileNamePrefix
+		String outputFileNamePrefix
 		String tumorSampleName
 		File tumorvcf
 		File tumorvcfindex
@@ -161,11 +161,11 @@ task filterVCF {
 
 task detectSNVs {
 	input {
-		File plasmabam
-		File plasmabai
+		File? plasmabam
+		File? plasmabai
 		String outputFileNamePrefix
 		File tumorvcf
-		String plasmaSampleName = basename(plasmabam, ".bam")
+		String? plasmaSampleName 
 		String tumorSampleName = basename(tumorvcf, ".vcf")
 		String modules = "mrdetect/1.1.1 pwgs-blocklist/hg38.1"
 		Int jobMemory = 64
@@ -200,6 +200,8 @@ task detectSNVs {
 	command <<<
 		set -euo pipefail
 
+		plasmaSampleName = basename(plasmabam)
+
 		~{pullreadsScript} \
 			--bam ~{plasmabam} \
 			--vcf ~{tumorvcf} \
@@ -228,9 +230,9 @@ task detectSNVs {
 	}
 
 	output {
-		File snvDetectionReadsScored = "PLASMA_VS_TUMOR.svm.tsv" 
+		File? snvDetectionReadsScored = "PLASMA_VS_TUMOR.svm.tsv" 
 		File? snvDetectionFinalResult = "~{plasmaSampleName}.mrdetect.results.csv"
-		File snvDetectionVAF = "~{plasmaSampleName}.mrdetect.vaf.txt"
+		File? snvDetectionVAF = "~{plasmaSampleName}.mrdetect.vaf.txt"
 	}
 
 	meta {

--- a/mrdetect.wdl
+++ b/mrdetect.wdl
@@ -41,6 +41,7 @@ workflow mrdetect {
 				input:
 				plasmabam = control[0],
 				plasmabai = control[1],
+				plasmaSampleName = basename(control[0], ".bam"),
 				tumorvcf = filterVCF.filteredvcf,
 				outputFileNamePrefix = outputFileNamePrefix
 			}
@@ -166,6 +167,7 @@ task detectSNVs {
 		File? plasmabai
 		String outputFileNamePrefix
 		File tumorvcf
+		String? plasmaSampleName 
 		String tumorSampleName = basename(tumorvcf, ".vcf")
 		String modules = "mrdetect/1.1.1 pwgs-blocklist/hg38.1"
 		Int jobMemory = 64
@@ -183,6 +185,7 @@ task detectSNVs {
 		plasmabai: "plasma input .bai file"
 		outputFileNamePrefix: "Prefix for output file"
 		tumorvcf: "filtered tumor vcf file"
+		plasmaSampleName: "name for plasma sample (from bam)"
 		tumorSampleName: "name for tumour sample (from vcf)"
 		modules: "Required environment modules"
 		jobMemory: "Memory allocated for this job (GB)"
@@ -199,8 +202,6 @@ task detectSNVs {
 	command <<<
 		set -euo pipefail
 
-		plasmaSampleName=$(basename ~{plasmabam})
-
 		~{pullreadsScript} \
 			--bam ~{plasmabam} \
 			--vcf ~{tumorvcf} \
@@ -212,7 +213,7 @@ task detectSNVs {
 			--output_file PLASMA_VS_TUMOR.svm.tsv
 
 		~{filterAndDetectScript} \
-			--vcfid ~{tumorSampleName} --bamid $plasmaSampleName \
+			--vcfid ~{tumorSampleName} --bamid ~{plasmaSampleName} \
 			--svm PLASMA_VS_TUMOR.svm.tsv \
 			--vcf ~{tumorvcf} \
 			--output ./ \

--- a/mrdetect.wdl
+++ b/mrdetect.wdl
@@ -93,6 +93,7 @@ workflow mrdetect {
 		File snpcount = filterVCF.snpcount
 		File? snvDetectionVAF = detectSample.snvDetectionVAF
 		File? final_call = snvDetectionSummary.final_call
+		File? filteredvcf = filterVCF.filteredvcf
 	}
 }
 

--- a/mrdetect.wdl
+++ b/mrdetect.wdl
@@ -166,7 +166,6 @@ task detectSNVs {
 		File? plasmabai
 		String outputFileNamePrefix
 		File tumorvcf
-		String? plasmaSampleName 
 		String tumorSampleName = basename(tumorvcf, ".vcf")
 		String modules = "mrdetect/1.1.1 pwgs-blocklist/hg38.1"
 		Int jobMemory = 64
@@ -184,7 +183,6 @@ task detectSNVs {
 		plasmabai: "plasma input .bai file"
 		outputFileNamePrefix: "Prefix for output file"
 		tumorvcf: "filtered tumor vcf file"
-		plasmaSampleName: "name for plasma sample (from bam)"
 		tumorSampleName: "name for tumour sample (from vcf)"
 		modules: "Required environment modules"
 		jobMemory: "Memory allocated for this job (GB)"

--- a/mrdetect.wdl
+++ b/mrdetect.wdl
@@ -4,6 +4,7 @@ workflow mrdetect {
 	input {
 		File? plasmabam
 		File? plasmabai
+		String? plasmaSampleName 
 		String outputFileNamePrefix
 		String tumorSampleName
 		File tumorvcf
@@ -15,6 +16,7 @@ workflow mrdetect {
 	parameter_meta {
 		plasmabam: "plasma input .bam file"
 		plasmabai: "plasma input .bai file"
+		plasmaSampleName: "name for plasma sample (from bam)"
 		tumorvcf: "tumor vcf file, bgzip"
 		tumorvcfindex: "tumor vcf index file"
 		outputFileNamePrefix: "Prefix for output file"
@@ -51,6 +53,7 @@ workflow mrdetect {
 			input:
 			plasmabam = plasmabam,
 			plasmabai = plasmabai,
+			plasmaSampleName = plasmaSampleName,
 			tumorvcf = filterVCF.filteredvcf,
 			outputFileNamePrefix = outputFileNamePrefix
 		}

--- a/tests/filter_only_calculate.sh
+++ b/tests/filter_only_calculate.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -o nounset
+set -o errexit
+set -o pipefail
+
+cd $1
+
+find -name SNP.count.txt | grep -v _dis | xargs md5sum 
+find . -name *.vcf | grep -v ^# | xargs md5sum

--- a/tests/filter_only_calculate.sh
+++ b/tests/filter_only_calculate.sh
@@ -6,4 +6,4 @@ set -o pipefail
 cd $1
 
 find -name SNP.count.txt | grep -v _dis | xargs md5sum 
-find . -name *.vcf | grep -v ^# | xargs md5sum
+ls | sed 's/.*\.//' | sort | uniq -c

--- a/vidarrbuild.json
+++ b/vidarrbuild.json
@@ -1,6 +1,7 @@
 {
     "names": [
-        "mrdetect"
+        "mrdetect",
+        "mrdetect_filter_only"
     ],
     "wdl": "mrdetect.wdl"
 }

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -1,5 +1,164 @@
 [
-        {
+    {
+        "arguments": {
+            "mrdetect.tumorvcf": {
+                "contents": {
+                    "configuration": "/.mounts/labs/gsi/testdata/mrdetect/1.0/input_data/TGL49_0143_Br_P_WG.chr21.vcf.gz",
+                    "externalIds": [
+                        {
+                            "id": "TEST",
+                            "provider": "TEST"
+                        }
+                    ]
+                },
+                "type": "EXTERNAL"
+            },
+            "mrdetect.tumorvcfindex": {
+                "contents": {
+                    "configuration": "/.mounts/labs/gsi/testdata/mrdetect/1.0/input_data/TGL49_0143_Br_P_WG.chr21.vcf.gz.tbi",
+                    "externalIds": [
+                        {
+                            "id": "TEST",
+                            "provider": "TEST"
+                        }
+                    ]
+                },
+                "type": "EXTERNAL"
+            },
+            "mrdetect.plasmabam": {
+                "contents": {
+                    "configuration": "/.mounts/labs/gsi/testdata/mrdetect/1.0/input_data/TGL49_0143_Ct_T_WG.chr21.bam",
+                    "externalIds": [
+                        {
+                            "id": "TEST",
+                            "provider": "TEST"
+                        }
+                    ]
+                },
+                "type": "EXTERNAL"
+            },
+            "mrdetect.plasmabai": {
+                "contents": {
+                    "configuration": "/.mounts/labs/gsi/testdata/mrdetect/1.0/input_data/TGL49_0143_Ct_T_WG.chr21.bam.bai",
+                    "externalIds": [
+                        {
+                            "id": "TEST",
+                            "provider": "TEST"
+                        }
+                    ]
+                },
+                "type": "EXTERNAL"
+            },
+            "mrdetect.plasmaSampleName": "TGL49_0143_Ct_T_WG.chr21",
+            "mrdetect.full_analysis_mode": true,
+            "mrdetect.detectSample.blocklist": "/.mounts/labs/gsi/testdata/mrdetect/1.0/input_data/HBCs.blacklist.chr21.vcf.gz",
+            "mrdetect.detectControl.blocklist": "/.mounts/labs/gsi/testdata/mrdetect/1.0/input_data/HBCs.blacklist.chr21.vcf.gz",
+            "mrdetect.controlFileList": "/.mounts/labs/gsi/testdata/mrdetect/1.0/input_data/HBC.chr21.bam.list",
+            "mrdetect.outputFileNamePrefix": "TGL49_0143_Ct_T_WG",
+            "mrdetect.tumorSampleName": "TGL49_0143_Br_P_T-92",
+            "mrdetect.filterVCF.tumorVCFfilter": null,
+            "mrdetect.filterVCF.tumorVAF": null,
+            "mrdetect.filterVCF.genome": null,
+            "mrdetect.filterVCF.difficultRegions": null,
+            "mrdetect.filterVCF.modules": null,
+            "mrdetect.filterVCF.jobMemory": null,
+            "mrdetect.filterVCF.threads": null,
+            "mrdetect.filterVCF.timeout": null,
+            "mrdetect.parseControls.jobMemory": null,
+            "mrdetect.parseControls.timeout": null,
+            "mrdetect.detectControl.plasmaSampleName": null,
+            "mrdetect.detectControl.tumorSampleName": null,
+            "mrdetect.detectControl.modules": null,
+            "mrdetect.detectControl.jobMemory": null,
+            "mrdetect.detectControl.threads": null,
+            "mrdetect.detectControl.timeout": null,
+            "mrdetect.detectControl.pickle": null,
+            "mrdetect.detectControl.pullreadsScript": null,
+            "mrdetect.detectControl.qualityscoreScript": null,
+            "mrdetect.detectControl.filterAndDetectScript": null,
+            "mrdetect.detectSample.plasmaSampleName": null,
+            "mrdetect.detectSample.tumorSampleName": null,
+            "mrdetect.detectSample.modules": null,
+            "mrdetect.detectSample.jobMemory": null,
+            "mrdetect.detectSample.threads": null,
+            "mrdetect.detectSample.timeout": null,
+            "mrdetect.detectSample.pickle": null,
+            "mrdetect.detectSample.pullreadsScript": null,
+            "mrdetect.detectSample.qualityscoreScript": null,
+            "mrdetect.detectSample.filterAndDetectScript": null,
+            "mrdetect.snvDetectionSummary.pvalue": "0.01",
+            "mrdetect.snvDetectionSummary.jobMemory": null,
+            "mrdetect.snvDetectionSummary.threads": null,
+            "mrdetect.snvDetectionSummary.timeout": null,
+            "mrdetect.snvDetectionSummary.modules": null,
+            "mrdetect.snvDetectionSummary.pwgtestscript": null
+     },
+        "description": "mrdetect workflow test",
+        "engineArguments": {
+          "write_to_cache": false,
+          "read_from_cache": false
+        },
+        "id": "TGL49_0143Test",
+        "metadata": {
+            "mrdetect.final_call": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_mrdetect_TGL49_0143Test_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "mrdetect.snvDetectionVAF": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_mrdetect_TGL49_0143Test_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "mrdetect.snpcount": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_mrdetect_TGL49_0143Test_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "mrdetect.snvDetectionResult": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_mrdetect_TGL49_0143Test_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "mrdetect.pWGS_svg": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_mrdetect_TGL49_0143Test_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "mrdetect.filteredvcf": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_mrdetect_TGL49_0143Test_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            }
+        },
+        "validators": [
+            {
+                "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
+                "metrics_compare": "@CHECKOUT@/tests/compare.sh",
+                "output_metrics": "/.mounts/labs/gsi/testdata/mrdetect/1.1/output_metrics/TGL49_0143Test.metrics",
+                "type": "script"
+            }  
+        ]
+    },    
+    {
         "arguments": {
             "mrdetect.tumorvcf": {
                 "contents": {
@@ -134,163 +293,5 @@
                 "type": "script"
             }  
         ]
-    },
-    {
-        "arguments": {
-            "mrdetect.tumorvcf": {
-                "contents": {
-                    "configuration": "/.mounts/labs/gsi/testdata/mrdetect/1.0/input_data/TGL49_0143_Br_P_WG.chr21.vcf.gz",
-                    "externalIds": [
-                        {
-                            "id": "TEST",
-                            "provider": "TEST"
-                        }
-                    ]
-                },
-                "type": "EXTERNAL"
-            },
-            "mrdetect.tumorvcfindex": {
-                "contents": {
-                    "configuration": "/.mounts/labs/gsi/testdata/mrdetect/1.0/input_data/TGL49_0143_Br_P_WG.chr21.vcf.gz.tbi",
-                    "externalIds": [
-                        {
-                            "id": "TEST",
-                            "provider": "TEST"
-                        }
-                    ]
-                },
-                "type": "EXTERNAL"
-            },
-            "mrdetect.plasmabam": {
-                "contents": {
-                    "configuration": "/.mounts/labs/gsi/testdata/mrdetect/1.0/input_data/TGL49_0143_Ct_T_WG.chr21.bam",
-                    "externalIds": [
-                        {
-                            "id": "TEST",
-                            "provider": "TEST"
-                        }
-                    ]
-                },
-                "type": "EXTERNAL"
-            },
-            "mrdetect.plasmabai": {
-                "contents": {
-                    "configuration": "/.mounts/labs/gsi/testdata/mrdetect/1.0/input_data/TGL49_0143_Ct_T_WG.chr21.bam.bai",
-                    "externalIds": [
-                        {
-                            "id": "TEST",
-                            "provider": "TEST"
-                        }
-                    ]
-                },
-                "type": "EXTERNAL"
-            },
-            "mrdetect.full_analysis_mode": true,
-            "mrdetect.detectSample.blocklist": "/.mounts/labs/gsi/testdata/mrdetect/1.0/input_data/HBCs.blacklist.chr21.vcf.gz",
-            "mrdetect.detectControl.blocklist": "/.mounts/labs/gsi/testdata/mrdetect/1.0/input_data/HBCs.blacklist.chr21.vcf.gz",
-            "mrdetect.controlFileList": "/.mounts/labs/gsi/testdata/mrdetect/1.0/input_data/HBC.chr21.bam.list",
-            "mrdetect.outputFileNamePrefix": "TGL49_0143_Ct_T_WG",
-            "mrdetect.tumorSampleName": "TGL49_0143_Br_P_T-92",
-            "mrdetect.filterVCF.tumorVCFfilter": null,
-            "mrdetect.filterVCF.tumorVAF": null,
-            "mrdetect.filterVCF.genome": null,
-            "mrdetect.filterVCF.difficultRegions": null,
-            "mrdetect.filterVCF.modules": null,
-            "mrdetect.filterVCF.jobMemory": null,
-            "mrdetect.filterVCF.threads": null,
-            "mrdetect.filterVCF.timeout": null,
-            "mrdetect.parseControls.jobMemory": null,
-            "mrdetect.parseControls.timeout": null,
-            "mrdetect.detectControl.plasmaSampleName": null,
-            "mrdetect.detectControl.tumorSampleName": null,
-            "mrdetect.detectControl.modules": null,
-            "mrdetect.detectControl.jobMemory": null,
-            "mrdetect.detectControl.threads": null,
-            "mrdetect.detectControl.timeout": null,
-            "mrdetect.detectControl.pickle": null,
-            "mrdetect.detectControl.pullreadsScript": null,
-            "mrdetect.detectControl.qualityscoreScript": null,
-            "mrdetect.detectControl.filterAndDetectScript": null,
-            "mrdetect.detectSample.plasmaSampleName": null,
-            "mrdetect.detectSample.tumorSampleName": null,
-            "mrdetect.detectSample.modules": null,
-            "mrdetect.detectSample.jobMemory": null,
-            "mrdetect.detectSample.threads": null,
-            "mrdetect.detectSample.timeout": null,
-            "mrdetect.detectSample.pickle": null,
-            "mrdetect.detectSample.pullreadsScript": null,
-            "mrdetect.detectSample.qualityscoreScript": null,
-            "mrdetect.detectSample.filterAndDetectScript": null,
-            "mrdetect.snvDetectionSummary.pvalue": "0.01",
-            "mrdetect.snvDetectionSummary.jobMemory": null,
-            "mrdetect.snvDetectionSummary.threads": null,
-            "mrdetect.snvDetectionSummary.timeout": null,
-            "mrdetect.snvDetectionSummary.modules": null,
-            "mrdetect.snvDetectionSummary.pwgtestscript": null
-     },
-        "description": "mrdetect workflow test",
-        "engineArguments": {
-          "write_to_cache": false,
-          "read_from_cache": false
-        },
-        "id": "TGL49_0143Test",
-        "metadata": {
-            "mrdetect.final_call": {
-                "contents": [
-                    {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_mrdetect_TGL49_0143Test_@JENKINSID@"
-                    }
-                ],
-                "type": "ALL"
-            },
-            "mrdetect.snvDetectionVAF": {
-                "contents": [
-                    {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_mrdetect_TGL49_0143Test_@JENKINSID@"
-                    }
-                ],
-                "type": "ALL"
-            },
-            "mrdetect.snpcount": {
-                "contents": [
-                    {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_mrdetect_TGL49_0143Test_@JENKINSID@"
-                    }
-                ],
-                "type": "ALL"
-            },
-            "mrdetect.snvDetectionResult": {
-                "contents": [
-                    {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_mrdetect_TGL49_0143Test_@JENKINSID@"
-                    }
-                ],
-                "type": "ALL"
-            },
-            "mrdetect.pWGS_svg": {
-                "contents": [
-                    {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_mrdetect_TGL49_0143Test_@JENKINSID@"
-                    }
-                ],
-                "type": "ALL"
-            },
-            "mrdetect.filteredvcf": {
-                "contents": [
-                    {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_mrdetect_TGL49_0143Test_@JENKINSID@"
-                    }
-                ],
-                "type": "ALL"
-            }
-        },
-        "validators": [
-            {
-                "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
-                "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/mrdetect/1.1/output_metrics/TGL49_0143Test.metrics",
-                "type": "script"
-            }  
-        ]
-    } 
+    }
 ]

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -130,7 +130,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/filter_only_calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/mrdetect/1.1/output_metrics/filter_only_metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/mrdetect/1.0.5/output_metrics/filter_only_metrics",
                 "type": "script"
             }  
         ]

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -117,7 +117,7 @@
                 ],
                 "type": "ALL"
             },
-            "mrdetect.final_cal": {
+            "mrdetect.final_call": {
                 "contents": [
                     {
                         "outputDirectory": "@SCRATCH@/@DATE@_Workflow_mrdetect_filter_only_Test_@JENKINSID@"

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -1,4 +1,106 @@
 [
+        {
+        "arguments": {
+            "mrdetect.tumorvcf": {
+                "contents": {
+                    "configuration": "/.mounts/labs/gsi/testdata/mrdetect/1.0/input_data/TGL49_0143_Br_P_WG.chr21.vcf.gz",
+                    "externalIds": [
+                        {
+                            "id": "TEST",
+                            "provider": "TEST"
+                        }
+                    ]
+                },
+                "type": "EXTERNAL"
+            },
+            "mrdetect.tumorvcfindex": {
+                "contents": {
+                    "configuration": "/.mounts/labs/gsi/testdata/mrdetect/1.0/input_data/TGL49_0143_Br_P_WG.chr21.vcf.gz.tbi",
+                    "externalIds": [
+                        {
+                            "id": "TEST",
+                            "provider": "TEST"
+                        }
+                    ]
+                },
+                "type": "EXTERNAL"
+            },
+            "mrdetect.full_analysis_mode": false,
+            "mrdetect.detectSample.blocklist": "/.mounts/labs/gsi/testdata/mrdetect/1.0/input_data/HBCs.blacklist.chr21.vcf.gz",
+            "mrdetect.detectControl.blocklist": "/.mounts/labs/gsi/testdata/mrdetect/1.0/input_data/HBCs.blacklist.chr21.vcf.gz",
+            "mrdetect.controlFileList": "/.mounts/labs/gsi/testdata/mrdetect/1.0/input_data/HBC.chr21.bam.list",
+            "mrdetect.outputFileNamePrefix": "TGL49_0143_Ct_T_WG",
+            "mrdetect.tumorSampleName": "TGL49_0143_Br_P_T-92",
+            "mrdetect.filterVCF.tumorVCFfilter": null,
+            "mrdetect.filterVCF.tumorVAF": null,
+            "mrdetect.filterVCF.genome": null,
+            "mrdetect.filterVCF.difficultRegions": null,
+            "mrdetect.filterVCF.modules": null,
+            "mrdetect.filterVCF.jobMemory": null,
+            "mrdetect.filterVCF.threads": null,
+            "mrdetect.filterVCF.timeout": null,
+            "mrdetect.parseControls.jobMemory": null,
+            "mrdetect.parseControls.timeout": null,
+            "mrdetect.detectControl.plasmaSampleName": null,
+            "mrdetect.detectControl.tumorSampleName": null,
+            "mrdetect.detectControl.modules": null,
+            "mrdetect.detectControl.jobMemory": null,
+            "mrdetect.detectControl.threads": null,
+            "mrdetect.detectControl.timeout": null,
+            "mrdetect.detectControl.pickle": null,
+            "mrdetect.detectControl.pullreadsScript": null,
+            "mrdetect.detectControl.qualityscoreScript": null,
+            "mrdetect.detectControl.filterAndDetectScript": null,
+            "mrdetect.detectSample.plasmaSampleName": null,
+            "mrdetect.detectSample.tumorSampleName": null,
+            "mrdetect.detectSample.modules": null,
+            "mrdetect.detectSample.jobMemory": null,
+            "mrdetect.detectSample.threads": null,
+            "mrdetect.detectSample.timeout": null,
+            "mrdetect.detectSample.pickle": null,
+            "mrdetect.detectSample.pullreadsScript": null,
+            "mrdetect.detectSample.qualityscoreScript": null,
+            "mrdetect.detectSample.filterAndDetectScript": null,
+            "mrdetect.snvDetectionSummary.pvalue": "0.01",
+            "mrdetect.snvDetectionSummary.jobMemory": null,
+            "mrdetect.snvDetectionSummary.threads": null,
+            "mrdetect.snvDetectionSummary.timeout": null,
+            "mrdetect.snvDetectionSummary.modules": null,
+            "mrdetect.snvDetectionSummary.pwgtestscript": null
+     },
+        "description": "mrdetect filter_only workflow test",
+        "engineArguments": {
+          "write_to_cache": false,
+          "read_from_cache": false
+        },
+        "id": "filter_only Test",
+        "metadata": {
+            "mrdetect.filteredvcf": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_mrdetect_filter_only_Test_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "mrdetect.snpcount": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_mrdetect_filter_only_Test_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            }
+        },
+        "validators": [
+            {
+                "metrics_calculate": "@CHECKOUT@/tests/filter_only_calculate.sh",
+                "metrics_compare": "@CHECKOUT@/tests/compare.sh",
+                "output_metrics": "/.mounts/labs/gsi/testdata/mrdetect/1.1/output_metrics/filter_only_metrics",
+                "type": "script"
+            }  
+        ]
+    },
     {
         "arguments": {
             "mrdetect.tumorvcf": {
@@ -49,6 +151,7 @@
                 },
                 "type": "EXTERNAL"
             },
+            "mrdetect.full_analysis_mode": true,
             "mrdetect.detectSample.blocklist": "/.mounts/labs/gsi/testdata/mrdetect/1.0/input_data/HBCs.blacklist.chr21.vcf.gz",
             "mrdetect.detectControl.blocklist": "/.mounts/labs/gsi/testdata/mrdetect/1.0/input_data/HBCs.blacklist.chr21.vcf.gz",
             "mrdetect.controlFileList": "/.mounts/labs/gsi/testdata/mrdetect/1.0/input_data/HBC.chr21.bam.list",

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -186,6 +186,7 @@
             },
             "mrdetect.plasmabam": null,
             "mrdetect.plasmabai": null,
+            "mrdetect.plasmaSampleName": null,
             "mrdetect.full_analysis_mode": false,
             "mrdetect.detectSample.blocklist": "/.mounts/labs/gsi/testdata/mrdetect/1.0/input_data/HBCs.blacklist.chr21.vcf.gz",
             "mrdetect.detectControl.blocklist": "/.mounts/labs/gsi/testdata/mrdetect/1.0/input_data/HBCs.blacklist.chr21.vcf.gz",

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -25,6 +25,8 @@
                 },
                 "type": "EXTERNAL"
             },
+            "mrdetect.plasmabam": null,
+            "mrdetect.plasmabai": null,
             "mrdetect.full_analysis_mode": false,
             "mrdetect.detectSample.blocklist": "/.mounts/labs/gsi/testdata/mrdetect/1.0/input_data/HBCs.blacklist.chr21.vcf.gz",
             "mrdetect.detectControl.blocklist": "/.mounts/labs/gsi/testdata/mrdetect/1.0/input_data/HBCs.blacklist.chr21.vcf.gz",
@@ -90,7 +92,11 @@
                     }
                 ],
                 "type": "ALL"
-            }
+            },
+            "mrdetect.snvDetectionResult": null,
+            "mrdetect.pWGS_svg": null,
+            "mrdetect.snvDetectionVAF": null,
+            "mrdetect.final_cal": null
         },
         "validators": [
             {
@@ -240,7 +246,8 @@
                     }
                 ],
                 "type": "ALL"
-            }
+            },
+            "mrdetect.filteredvcf": null
         },
         "validators": [
             {

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -93,10 +93,38 @@
                 ],
                 "type": "ALL"
             },
-            "mrdetect.snvDetectionResult": null,
-            "mrdetect.pWGS_svg": null,
-            "mrdetect.snvDetectionVAF": null,
-            "mrdetect.final_cal": null
+            "mrdetect.snvDetectionResult": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_mrdetect_filter_only_Test_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "mrdetect.pWGS_svg": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_mrdetect_filter_only_Test_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "mrdetect.snvDetectionVAF": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_mrdetect_filter_only_Test_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "mrdetect.final_cal": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_mrdetect_filter_only_Test_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            }
         },
         "validators": [
             {
@@ -247,7 +275,14 @@
                 ],
                 "type": "ALL"
             },
-            "mrdetect.filteredvcf": null
+            "mrdetect.filteredvcf": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_mrdetect_TGL49_0143Test_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            }
         },
         "validators": [
             {


### PR DESCRIPTION
In the filtervcf only mode, a lot of paramteres going optional, I made some changes to make it pass syntax check and regresssion test for the two modes. plasmaSampleName has to be supplied as input of workflow, as "basename" function in wdl needs non-optional parameter, and plasmaSampleName needed for task output name, so can't generated inside task.